### PR TITLE
Add function to find the longest key that is a prefix to a given string

### DIFF
--- a/src/trie.erl
+++ b/src/trie.erl
@@ -112,6 +112,8 @@
 -type trie_return() :: {integer(), integer(), tuple()}.
 -type trie() :: [] | trie_return().
 
+-export_type([trie/0]).
+
 %%-------------------------------------------------------------------------
 %% @doc
 %% ===Append a value as a list element in a trie instance.===


### PR DESCRIPTION
I've added the function `find_longest_prefix/2` that retrieves the key that is the longest prefix to a string that is passed as an argument.

e.g.: Given a trie `T` that was created from the list `[{"ab", 0}, {"abc", 1}, {"cde", 2}]`, the call to:

``` erlang
trie:find_longest_prefix("abcdef", T)
```

will return `{ok, "abc", 1}`.

Please let me know if there is anything else I need to add for you to merge the pull request to your repository.
