### PR TITLE
Include LICENSE file when publishing to hex

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule Trie.Mixfile do
   end
 
   defp package do
-    [files: ~w(src doc test rebar.config README.markdown),
+    [files: ~w(src doc test rebar.config README.markdown LICENSE),
      maintainers: ["Michael Truog"],
      licenses: ["MIT"],
      links: %{"GitHub" => "https://github.com/okeuday/trie"}]


### PR DESCRIPTION
Makes it easier for tools to parse license information and generate 3rd-party license notices files.
Also the license file should always be included when distributing a package.